### PR TITLE
Make one ticker rather than a timer each iteration

### DIFF
--- a/codelingo.yaml
+++ b/codelingo.yaml
@@ -1,3 +1,4 @@
 tenets:
 - import: codelingo/effective-go
+- import: codelingo/go/ticker-in-for-select
 - import: codelingo/code-review-comments

--- a/session/connio.go
+++ b/session/connio.go
@@ -50,12 +50,14 @@ func (c *Conn) DoLogin(ctx context.Context) {
 }
 
 func (c *Conn) HeartBeatLoop(ctx context.Context) {
+	ticker := time.NewTicker(time.Second * 4)
 	for {
 		select {
 		case <-ctx.Done():
+			ticker.Stop()
 			return
 
-		case <-time.After(time.Second * 4):
+		case <-ticker.C:
 			var hb = &unified.MsgHeartBeat{}
 			data, err := c.coder.Encode(hb)
 			if err != nil {


### PR DESCRIPTION
Rather than creating a new timer for each iteration, one timer should be defined and reset after each iteration. When using time.After() it's valuable to know that ["The underlying Timer is not recovered by the garbage collector until the timer fires. If efficiency is a concern, use NewTimer instead and call Timer.Stop if the timer is no longer needed."](https://golang.org/src/time/sleep.go?s=4332:4733#L143)

This issue was found using the CodeLingo Tenet [ticker-in-for-select](https://github.com/codelingo/codelingo/blob/master/tenets/codelingo/go/ticker-in-for-select/codelingo.yaml) which I have added to the codelingo.yaml at the root of the repo.